### PR TITLE
Fixed build failure in Node v12.14.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const crypto = require('crypto');
+const os = require('os');
 
-function md5() {
+function md5(str) {
   let md5sum = crypto.createHash('md5');
   md5sum.update(str);
   return md5sum.digest('hex');

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Interprocess shared memory cache for Node.JS",
   "main": "index.js",
   "dependencies": {
-    "nan": "~2.4.0"
+    "nan": "^2.14.0"
   },
   "devDependencies": {},
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-shared-cache-x",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "Interprocess shared memory cache for Node.JS",
   "main": "index.js",
   "dependencies": {

--- a/src_v12/binding.cc
+++ b/src_v12/binding.cc
@@ -74,7 +74,7 @@ HANDLE intToHandle(uint32_t idx)
 static NAN_METHOD(release)
 {
 #ifndef _WIN32
-    FATALIF(shm_unlink(*String::Utf8Value(info[0])), -1, shm_unlink);
+    FATALIF(shm_unlink(*String::Utf8Value(info.GetIsolate(), info[0])), -1, shm_unlink);
 #endif
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -63,7 +63,7 @@ assert.strictEqual(binding.fastGet(obj, 'blah'), 'mew');
 assert.strictEqual(binding.fastGet(obj, 'blah~'), undefined);
 
 delete obj.foo;
-assert.ifError('foo' in obj);
+assert.ifError(obj['foo']);
 assert.strictEqual(obj.foo, undefined);
 
 console.time('LRU cache replacement');
@@ -72,7 +72,7 @@ for(var i = 0; i < 1000000; i+=3) {
     assert.strictEqual(obj['test' + i] , i);
 }
 console.timeEnd('LRU cache replacement');
-assert.ifError('test0' in obj);
+assert.ifError(obj['test0']);
 
 var longData = Array(15).join(Array(64).join('abcdefgh')); // 17 blocks
 


### PR DESCRIPTION
Additionally, fixed the tests, as two of them were wrongly expecting `null` while the `in` operator in JS actually returns `Boolean` (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/in).